### PR TITLE
Fix onnx conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ python3 onnx_conversion.py -p <checkpoint> -o <onnx_file_path>
 
 python3 trt_conversion.py -o <onnx_file_path> -t <trt_file_path>
 ```
-**Note:** TensorRT engines are specific to both the TensorRT version and the GPU on which they are created. Therefore, it's recommended to rebuild the engine outside of docker on the target platform to run inference.
+**Note:** 1) Image size should be adjusted to match the camera resolution in ONNX conversion. 2) TensorRT engines are specific to both the TensorRT version and the GPU on which they are created. Therefore, it's recommended to rebuild the engine outside of docker on the target platform to run inference.
 
 
 6. E2E navigation with ROS2:
@@ -71,7 +71,7 @@ X-Mobility is released under the Apache License 2.0. See LICENSE for additional 
 Wei Liu, Huihua Zhao, Chenran Li, Joydeep Biswas, Billy Okal, Pulkit Goyal, Soha Pouya, Yan Chang
 
 ## Upcoming Features
-Stay tuned for the upcoming RL enhancements for embodiments using Isaac Lab. 
+Stay tuned for the upcoming RL enhancements for embodiments using Isaac Lab.
 
 ## Acknowledgments
 We would like to acknowledge the following projects where parts of the codes in this repo is derived from:

--- a/onnx_conversion.py
+++ b/onnx_conversion.py
@@ -79,7 +79,8 @@ def convert(checkpoint_path: str, onnx_path: str, enable_semantic: bool,
     model.eval()
 
     # Input tensors.
-    image = torch.randn((1, 1, 3, 640, 960), dtype=torch.float32).to(device)
+    # Note: Image size should be adjusted to match the camera resolution.
+    image = torch.randn((1, 1, 3, 1200, 1920), dtype=torch.float32).to(device)
     speed = torch.randn((1, 1, 1), dtype=torch.float32).to(device)
     action = torch.randn((1, 6), dtype=torch.float32).to(device)
     history = torch.zeros((1, 1024), dtype=torch.float32).to(device)

--- a/ros2_deployment/README.md
+++ b/ros2_deployment/README.md
@@ -27,7 +27,7 @@ provided.
 
 1. Install NVIDIA TensorRT following the guides [here](https://docs.nvidia.com/deeplearning/tensorrt/10.8.0/installing-tensorrt/installing.html#).
 2. Test the installation by calling ``python3 -c "import tensorrt"``
-3. Install PyCUDA 
+3. Install PyCUDA
 
     ```bash
     pip3 install pycuda
@@ -53,7 +53,7 @@ provided.
     cd ~/ros2_ws
     ```
 
-    and 
+    and
 
     ```bash
     colcon build --symlink-install
@@ -69,7 +69,7 @@ provided.
     ```
 3. Copy the TensorRT engine to ``/tmp/x_mobility.engine``.  The x_mobility_navigator launch file uses this path by default.
 
-Now you have everything needed to run the ``x_mobility_navigator`` package.  
+Now you have everything needed to run the ``x_mobility_navigator`` package.
 
 But we'll return to this step later, first we need to enable ROS2 with Isaac Sim.
 

--- a/ros2_deployment/x_mobility_navigator/x_mobility_navigator/x_mobility_navigator.py
+++ b/ros2_deployment/x_mobility_navigator/x_mobility_navigator/x_mobility_navigator.py
@@ -131,6 +131,9 @@ class XMobilityNavigator(Node):
 
     def goal_callback(self, goal_msg):
         self.goal = goal_msg
+        # Reset history state
+        self.history = np.zeros((1, 1024), dtype=np.float32)
+        self.sample = np.zeros((1, 512), dtype=np.float32)
 
     def route_callback(self, route_msg):
         # Get transform between route and robot.
@@ -271,15 +274,14 @@ class XMobilityNavigator(Node):
         self.cmd_publisher.publish(cmd_vel)
 
     def publish_path(self):
-        # print(self.path)
         path = Path()
         path.header.frame_id = ROBOT_FRAME
         path.header.stamp = self.get_clock().now().to_msg()
-        for idx in range(5):
+        for idx in range(len(self.route_vectors)):
             path_pose = PoseStamped()
             path_pose.header = path.header
-            path_pose.pose.position.x = float(self.path[2 * idx])
-            path_pose.pose.position.y = float(self.path[2 * idx + 1])
+            path_pose.pose.position.x = float(self.route_vectors[idx][0])
+            path_pose.pose.position.y = float(self.route_vectors[idx][1])
             path.poses.append(path_pose)
         self.path_publisher.publish(path)
 


### PR DESCRIPTION
Problem:
The image size was not properly set during ONNX conversion, makes the tensor size not aligned between ONNX and the camera image from Isaac Sim, causing low speed motions. 

Solutions:
- Update the default image size to match Isaac Sim in ONNX conversions
- Publish the route instead of path instead to avoid confusion, as the path has no impact on navigation under current setting
- Reset history state when a new goal is received. 
- Fix lint errors

Test plan:
- Tested locally, the robot can reach maximum speed ~0.5m/s. 
- Performance still downgraded with simplified route, a better route or future RL fine-tuning pipeline should improve this

https://github.com/user-attachments/assets/40366d88-eafa-4738-a76e-35deed9312d6

