### PR TITLE
add demo video of isaac sim

### DIFF
--- a/ros2_deployment/README.md
+++ b/ros2_deployment/README.md
@@ -196,4 +196,4 @@ Now let's launch the X-Mobility package
 
 That's it!  If everything worked, you should see the robot moving towards the goal pose in the simulation.
 
-<img src="../images/ros2_navigation_with_rviz.png" height=320>
+<video src="../images/x_mobility_demo_short.mp4" controls width=640/>

--- a/ros2_deployment/README.md
+++ b/ros2_deployment/README.md
@@ -196,4 +196,6 @@ Now let's launch the X-Mobility package
 
 That's it!  If everything worked, you should see the robot moving towards the goal pose in the simulation.
 
-<video src="../images/x_mobility_demo_short.mp4" controls width=640/>
+
+https://github.com/user-attachments/assets/32931225-60b1-4fbb-8f17-1b7e7641808f
+

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ def load_requirements(filename):
 setup(
     name='x_mobility',
     version='0.1.0',
-    packages=find_packages(where='model'),
-    package_dir={'': 'model'},
+    packages=find_packages(),
+    package_dir={"": "."},
     author='Wei Liu',
     author_email='liuw@nvidia.com',
     description='Python package for X-Mobility',


### PR DESCRIPTION
Problem:
- ROS2 README only contains a duplicated image as example
- setup.py breaks the internal imports


Solution:
- Add a recorded video for X-Mobility
- Fix setup.py

Test plan:
- Video plays during local preview