### PR TITLE
[docker] fix diffuser pkg version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-diffusers
+diffusers==0.29.2
 einops
 gin-config
 matplotlib


### PR DESCRIPTION
Problem: The latest diffuser pkg doesn't work with torch 2.2
Solution: Specify a working version in requirements.txt
Tested locally